### PR TITLE
Add Flask-based project management skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# PM
+# Project Management Tool
+
+This repository contains a simple project management web application built with Flask. It provides basic functionality for managing tasks and work breakdown structure (WBS) items. The application stores its data in a SQLite database that can be placed on an on-premise server or any path you choose.
+
+## Features
+
+- Dashboard showing recent tasks and top-level WBS items
+- Task list with form to add new tasks
+- WBS page to create and list items
+- Simple Bootstrap-based interface
+
+## Requirements
+
+- Python 3.8+
+- Packages listed in `requirements.txt`
+
+## Setup
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. (Optional) Specify a custom database path by setting the `APP_DATABASE_PATH` environment variable. If omitted, `pm.db` will be created in the project directory.
+3. Start the application:
+   ```bash
+   python run.py
+   ```
+4. Open `http://localhost:5000` in your browser.
+
+The database file will be created automatically at the specified path. Team members can share the database on an on-premise server by pointing `APP_DATABASE_PATH` to the shared location.

--- a/pm_tool/__init__.py
+++ b/pm_tool/__init__.py
@@ -1,0 +1,22 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+import os
+
+
+db = SQLAlchemy()
+
+
+def create_app(database_path=None):
+    app = Flask(__name__)
+    if not database_path:
+        database_path = os.environ.get("APP_DATABASE_PATH", "pm.db")
+    app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{database_path}"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    db.init_app(app)
+
+    with app.app_context():
+        from . import models, views
+        db.create_all()
+        app.register_blueprint(views.bp)
+    return app

--- a/pm_tool/models.py
+++ b/pm_tool/models.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from . import db
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+
+
+class Task(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    due_date = db.Column(db.Date, nullable=True)
+    completed = db.Column(db.Boolean, default=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    user = db.relationship('User', backref=db.backref('tasks', lazy=True))
+
+
+class WBSItem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    parent_id = db.Column(db.Integer, db.ForeignKey('wbs_item.id'), nullable=True)
+    parent = db.relationship('WBSItem', remote_side=[id], backref='children')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/pm_tool/static/style.css
+++ b/pm_tool/static/style.css
@@ -1,0 +1,3 @@
+body {
+    padding-top: 20px;
+}

--- a/pm_tool/templates/base.html
+++ b/pm_tool/templates/base.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <title>PM Tool</title>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('main.index') }}">PM Tool</a>
+        <div class="collapse navbar-collapse">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('main.tasks') }}">Tasks</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('main.wbs') }}">WBS</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/pm_tool/templates/index.html
+++ b/pm_tool/templates/index.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+  <h1>Dashboard</h1>
+  <p>Recent tasks</p>
+  <ul>
+    {% for task in tasks %}
+    <li>{{ task.title }}{% if task.completed %} (done){% endif %}</li>
+    {% else %}
+    <li>No tasks</li>
+    {% endfor %}
+  </ul>
+  <p>Top-level WBS items</p>
+  <ul>
+    {% for item in wbs_items %}
+    <li>{{ item.name }}</li>
+    {% else %}
+    <li>No items</li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/pm_tool/templates/tasks.html
+++ b/pm_tool/templates/tasks.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+  <h1>Tasks</h1>
+  <form method="post" action="{{ url_for('main.add_task') }}" class="mb-4">
+    <div class="mb-3">
+      <input type="text" name="title" placeholder="Task title" class="form-control" required>
+    </div>
+    <div class="mb-3">
+      <textarea name="description" placeholder="Description" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Add Task</button>
+  </form>
+  <ul class="list-group">
+    {% for task in tasks %}
+    <li class="list-group-item">{{ task.title }}</li>
+    {% else %}
+    <li class="list-group-item">No tasks</li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/pm_tool/templates/wbs.html
+++ b/pm_tool/templates/wbs.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+  <h1>WBS</h1>
+  <form method="post" action="{{ url_for('main.add_wbs_item') }}" class="mb-4">
+    <div class="mb-3">
+      <input type="text" name="name" placeholder="Item name" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Add Item</button>
+  </form>
+  <ul>
+    {% for item in items %}
+    <li>{{ item.name }}</li>
+    {% else %}
+    <li>No items</li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/pm_tool/views.py
+++ b/pm_tool/views.py
@@ -1,0 +1,44 @@
+from flask import Blueprint, render_template, request, redirect, url_for
+from .models import Task, WBSItem, User
+from . import db
+
+
+bp = Blueprint('main', __name__)
+
+
+@bp.route('/')
+def index():
+    tasks = Task.query.all()
+    wbs_items = WBSItem.query.filter_by(parent_id=None).all()
+    return render_template('index.html', tasks=tasks, wbs_items=wbs_items)
+
+
+@bp.route('/tasks')
+def tasks():
+    tasks = Task.query.all()
+    return render_template('tasks.html', tasks=tasks)
+
+
+@bp.route('/tasks/add', methods=['POST'])
+def add_task():
+    title = request.form['title']
+    description = request.form.get('description')
+    task = Task(title=title, description=description)
+    db.session.add(task)
+    db.session.commit()
+    return redirect(url_for('main.tasks'))
+
+
+@bp.route('/wbs')
+def wbs():
+    items = WBSItem.query.filter_by(parent_id=None).all()
+    return render_template('wbs.html', items=items)
+
+
+@bp.route('/wbs/add', methods=['POST'])
+def add_wbs_item():
+    name = request.form['name']
+    item = WBSItem(name=name)
+    db.session.add(item)
+    db.session.commit()
+    return redirect(url_for('main.wbs'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/run.py
+++ b/run.py
@@ -1,0 +1,8 @@
+from pm_tool import create_app
+
+
+app = create_app()
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add simple Flask app for project management
- support tasks and WBS with SQLite database
- add Bootstrap templates for dashboard, tasks, and WBS
- document setup and usage in README

## Testing
- `python -m py_compile pm_tool/*.py run.py`
- ❌ `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687750cba59883218dc46dc7d81006de